### PR TITLE
Fixes sending wrong 5 character locales to stripe

### DIFF
--- a/src/CoreShop/Payum/StripeCheckoutBundle/Provider/LocaleProvider.php
+++ b/src/CoreShop/Payum/StripeCheckoutBundle/Provider/LocaleProvider.php
@@ -29,7 +29,7 @@ final class LocaleProvider implements LocaleProviderInterface
 
         $gatewayLanguage = $localeCode;
 
-        if (strpos($gatewayLanguage, '_') === true) {
+        if (strpos($gatewayLanguage, '_') !== false) {
             $splitGatewayLLanguage = explode('_', $gatewayLanguage);
             $gatewayLanguage = array_shift($splitGatewayLLanguage);
         }


### PR DESCRIPTION
**Problem:**
Currently using 5 character locales (e.g. en_GB)  will lead to the error attached in the files, because there is a minor bug in the detection of 5 character locales. They will not be detected as such, but being send right to stripe instead of being formatted to a 2 character locale (e.g. en).

**Fix:**
The function strpos will never return exactly true only false or an integer. Therefor the If-Condition will never be executed.
This is problematic for locales that have 5 chars like "en_GB". With the change 5 char locales would be supported and won't throw an error anymore.


![Strip-Response](https://user-images.githubusercontent.com/75034503/100254245-58420200-2f42-11eb-9773-f106144a314b.png)